### PR TITLE
[unpacking] Fix parsing malformed auto declarations starting with `(`

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1252,7 +1252,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
      * Parse auto declarations of the form:
      *   storageClass ident = init, ident = init, ... ;
      * and return the array of them.
-     * Starts with token on the first ident or '('.
+     * Starts with token on the first ident, or '(' with -preview=tuples.
      * Ends with scanner past closing ';'
      */
     private AST.Dsymbols* parseAutoDeclarations(STC storageClass, const(char)* comment)
@@ -4672,7 +4672,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
              *  (int x, auto y) = initializer;
              *  storage_class (a, b, ...) = initializer;
              */
-            if (token.value == TOK.leftParenthesis && isTupleNotation(&token))
+            if (global.params.tuples && token.value == TOK.leftParenthesis &&
+                isTupleNotation(&token))
             {
                 // TODO: can we merge this with the branch below?
                 AST.Dsymbols* a = parseAutoDeclarations(storage_class | (pAttrs ? pAttrs.storageClass : STC.none), comment);

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1242,7 +1242,7 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         AST.Expression _init = null;
         if (parseInitializer)
         {
-            check(TOK.assign);
+            check(TOK.assign, "unpack declaration");
             _init = parseAssignExp();
         }
         return new AST.UnpackDeclaration(unpackLoc, vars, _init, g_storage_class);
@@ -1264,10 +1264,10 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
         {
             const loc = token.loc;
             AST.Dsymbol s;
-            if (global.params.tuples && token.value == TOK.leftParenthesis &&
-                peekPastParen(&token).value == TOK.assign)
+            if (token.value == TOK.leftParenthesis)
             {
-                s = parseUnpackDeclaration(storageClass);
+                assert(global.params.tuples);
+                s = parseUnpackDeclaration(storageClass, true);
             }
             else
             {

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1176,8 +1176,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                 error("linkage specification not allowed within unpack declarations");+/
             if (udas) // TODO
                 error("user defined attributes not allowed within unpack declarations");
-            if (global.params.tuples && token.value == TOK.leftParenthesis)
+            if (token.value == TOK.leftParenthesis)
             {
+                // recurse
                 vars.push(parseUnpackDeclaration(storage_class, false, isParameter));
             }
             else

--- a/compiler/test/fail_compilation/unpacking.d
+++ b/compiler/test/fail_compilation/unpacking.d
@@ -2,10 +2,13 @@
 REQUIRED_ARGS: -preview=tuples -vcolumns
 TEST_OUTPUT:
 ---
-fail_compilation/unpacking.d(16,14): Error: unpacked variable `b` needs a type or at least one storage class, did you mean `auto b`?
-fail_compilation/unpacking.d(17,15): Error: unpacked variable `b` needs a type or at least one storage class, did you mean `auto b`?
-fail_compilation/unpacking.d(17,18): Error: unpacked variable `c` needs a type or at least one storage class, did you mean `auto c`?
-fail_compilation/unpacking.d(18,23): Error: unpacked variable `c` needs a type or at least one storage class, did you mean `auto c`?
+fail_compilation/unpacking.d(19,14): Error: unpacked variable `b` needs a type or at least one storage class, did you mean `auto b`?
+fail_compilation/unpacking.d(20,15): Error: unpacked variable `b` needs a type or at least one storage class, did you mean `auto b`?
+fail_compilation/unpacking.d(20,18): Error: unpacked variable `c` needs a type or at least one storage class, did you mean `auto c`?
+fail_compilation/unpacking.d(21,23): Error: unpacked variable `c` needs a type or at least one storage class, did you mean `auto c`?
+fail_compilation/unpacking.d(23,16): Error: found `,` when expecting `=` following unpack declaration
+fail_compilation/unpacking.d(24,10): Error: unexpected identifier `a` in declarator
+fail_compilation/unpacking.d(24,17): Error: unexpected identifier `b` in declarator
 ---
 */
 
@@ -16,4 +19,7 @@ void main()
     (int a, b) = tuple(1, "2"); // error
     (int a, (b, c)) = tuple(1, tuple("2", 3.0)); // error
     (int a, (auto b, c)) = tuple(1, tuple("2", 3.0)); // error
+
+    auto (a, b), c = t;
+    (int a, int b), c = t;
 }

--- a/compiler/test/fail_compilation/unpacking.d
+++ b/compiler/test/fail_compilation/unpacking.d
@@ -20,6 +20,6 @@ void main()
     (int a, (b, c)) = tuple(1, tuple("2", 3.0)); // error
     (int a, (auto b, c)) = tuple(1, tuple("2", 3.0)); // error
 
-    auto (a, b), c = t;
-    (int a, int b), c = t;
+    auto (a, b), c = t; // error
+    (int a, int b), c = t; // error
 }


### PR DESCRIPTION
Note: This pull depends on #6 as it extends the `fail_compilation` test, please merge that first.

See 2 bug fix commits - both bugs caused `VarDeclaration.this` to fail its `assert(ident);` contract.
Also remove unnecessary preview check when recursing.

