### PR TITLE
[unpacking] Add tests for invalid parameter storage classes

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -3148,7 +3148,11 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                                 {
                                     error("unpacking `auto ref` parameters is not supported");
                                 }
-                                unpack = parseUnpackDeclaration(storageClass & ~STC.lazy_ & ~STC.out_ | STC.temp | STC.ctfe, false, true);
+                                if (storageClass & STC.out_)
+                                {
+                                    error("unpacking `out` parameters is not supported");
+                                }
+                                unpack = parseUnpackDeclaration(storageClass & ~STC.lazy_ & ~STC.autoref & ~STC.out_ | STC.temp | STC.ctfe, false, true);
                                 ai = Identifier.generateId("__unpack");
                                 goto LskipType;
                             }

--- a/compiler/test/fail_compilation/unpacking.d
+++ b/compiler/test/fail_compilation/unpacking.d
@@ -2,14 +2,18 @@
 REQUIRED_ARGS: -preview=tuples -vcolumns
 TEST_OUTPUT:
 ---
-fail_compilation/unpacking.d(25,14): Error: unpacked variable `b` needs a type or at least one storage class, did you mean `auto b`?
-fail_compilation/unpacking.d(26,15): Error: unpacked variable `b` needs a type or at least one storage class, did you mean `auto b`?
-fail_compilation/unpacking.d(26,18): Error: unpacked variable `c` needs a type or at least one storage class, did you mean `auto c`?
-fail_compilation/unpacking.d(27,23): Error: unpacked variable `c` needs a type or at least one storage class, did you mean `auto c`?
-fail_compilation/unpacking.d(29,16): Error: found `,` when expecting `=` following unpack declaration
-fail_compilation/unpacking.d(30,10): Error: unexpected identifier `a` in declarator
-fail_compilation/unpacking.d(30,17): Error: unexpected identifier `b` in declarator
-fail_compilation/unpacking.d(32,17): Error: expected identifier after type `int` in unpack declaration
+fail_compilation/unpacking.d(29,14): Error: unpacked variable `b` needs a type or at least one storage class, did you mean `auto b`?
+fail_compilation/unpacking.d(30,15): Error: unpacked variable `b` needs a type or at least one storage class, did you mean `auto b`?
+fail_compilation/unpacking.d(30,18): Error: unpacked variable `c` needs a type or at least one storage class, did you mean `auto c`?
+fail_compilation/unpacking.d(31,23): Error: unpacked variable `c` needs a type or at least one storage class, did you mean `auto c`?
+fail_compilation/unpacking.d(33,16): Error: found `,` when expecting `=` following unpack declaration
+fail_compilation/unpacking.d(34,10): Error: unexpected identifier `a` in declarator
+fail_compilation/unpacking.d(34,17): Error: unexpected identifier `b` in declarator
+fail_compilation/unpacking.d(36,17): Error: expected identifier after type `int` in unpack declaration
+fail_compilation/unpacking.d(38,16): Error: `auto ref` unpacked variables are not supported
+fail_compilation/unpacking.d(39,25): Error: unpacking `auto ref` parameters is not supported
+fail_compilation/unpacking.d(40,21): Error: unpacking `lazy` parameters is not supported
+fail_compilation/unpacking.d(40,34): Error: unpacking `out` parameters is not supported
 ---
 */
 
@@ -20,7 +24,7 @@ struct Tuple(T...)
 }
 auto tuple(T...)(T args) => Tuple!T(args);
 
-void main()
+void main() // check parse errors
 {
     (int a, b) = tuple(1, "2"); // error
     (int a, (b, c)) = tuple(1, tuple("2", 3.0)); // error
@@ -30,4 +34,8 @@ void main()
     (int a, int b), c = t; // error
 
     (char a, int) = t; // error
+
+    (auto ref a,) = t; // error
+    alias a = (auto ref (x,)) {}; // error
+    alias a = (lazy (x,), y, out (z,)) {}; // error
 }


### PR DESCRIPTION
Add error for `out` parameters.
Ignore `auto ref` after parameter error to avoid unpack error.