### PR TITLE
[tuple-syntax] Fix assigning to tuple literal

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -8948,8 +8948,11 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
                                 break;
                             check(TOK.comma);
                         }
-                        e = new AST.TupleLiteralExp(loc, elements);
                         check(loc, TOK.rightParenthesis);
+                        if (token.value == TOK.assign)
+                            e = new AST.TupleExp(loc, elements);
+                        else
+                            e = new AST.TupleLiteralExp(loc, elements);
                         break;
                     }
                 }

--- a/compiler/test/runnable/tuples.d
+++ b/compiler/test/runnable/tuples.d
@@ -35,6 +35,11 @@ void main()
     assert(d == 7u);
     assert(e == 8);
 
+    // assign to literal - LHS is TupleExp
+    (a, b) = ("two", 3);
+    assert(a == "two");
+    assert(b == 3);
+
     // tuple type
     (int, char) t = (6, '7');
     assert(t == (6, '7'));
@@ -44,15 +49,24 @@ void main()
     assert(t == (8, '9'));
     assert(t[0] == 8);
     assert(t[1] == '9');
+    // assign
+    ref f() => x;
+    (f(), b) = t; // int,int = int,char
+    assert(x == 8);
+    assert(b == '9');
 
     (int,) t2;
     static assert(t2.length == 1);
     static assert(is(typeof(t2[0]) == int));
     t2 = (5,);
     assert(t2[0] == 5);
+    // assign
+    (t[0],) = t2;
+    assert(t[0] == 5);
 
     () t3 = ();
     t3 = ();
+    () = t3; // LHS is TupleLiteralExp, but it's a no-op anyway
     static assert(t3.length == 0);
 
     // foreach unpacking


### PR DESCRIPTION
Parse LHS of `(...,) = ` as a `TupleExp`. Assignment is then handled like assigning to an expression sequence of lvalues.

BTW in testing this I found that dmd was giving a misleading error message in some cases - see https://github.com/dlang/dmd/issues/21259. I submitted a fix though. So I haven't added any `fail_compilation` tests yet, although I have some, because the error messages should change if/when the dmd PR is merged.