### PR TITLE
[unpacking] Support `auto (a, int b) =`

### DIFF
--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -799,6 +799,9 @@ extern (C++) final class UnpackDeclaration : AttribDeclaration
             {
                 vd.storage_class |= declared_storage_class;
                 d_storage_class = vd.storage_class;
+                // allow `auto (a, int b) =`
+                if (vd.type)
+                    vd.storage_class &= ~STC.auto_;
             }
             else if (auto up = d.isUnpackDeclaration())
             {

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1200,6 +1200,9 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
 
                     if (t == AST.Type.terror)
                         break;
+                    // specifying type overrides outer `auto`
+                    if (g_storage_class & STC.auto_)
+                        storage_class &= ~STC.auto_;
 
                     if (token.value != TOK.identifier)
                     {

--- a/compiler/test/runnable/unpacking.d
+++ b/compiler/test/runnable/unpacking.d
@@ -24,6 +24,17 @@ void main()
     assert(a == "four");
     assert(b == 5);
 
+    {
+        // mix outer storage & pattern component with type
+        auto ((s, int i), c) = tuple(tuple("hi", 5), 'c');
+        static assert(is(typeof(s) == string));
+        static assert(is(typeof(i) == int));
+        static assert(is(typeof(c) == char));
+        assert(s == "hi");
+        assert(i == 5);
+        assert(c == 'c');
+    }
+
     scope (u, v) = tuple(1, 2);
     assert(u == 1);
     assert(v == 2);


### PR DESCRIPTION
Avoid lowering to `auto Type x =`, which causes a redundant `auto` error.