### PR TITLE
 [unpacking] Error when unpacking declaration itself has a UDA 

### DIFF
--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -845,6 +845,12 @@ extern (C++) final class UnpackDeclaration : AttribDeclaration
             decl = null;
             lowered = true;
         }
+        static import dmd.errors;
+        if (auto uda = userAttribDecl)
+        {
+            dmd.errors.error(loc, "user defined attributes are not supported yet on unpack declarations");
+            return fail();
+        }
 
         import dmd.expressionsem;
         bool needctfe = (storage_class & (STC.manifest | STC.static_)) != 0;
@@ -886,7 +892,6 @@ extern (C++) final class UnpackDeclaration : AttribDeclaration
             }
         }
 
-        static import dmd.errors;
         if (!tup)
         {
             dmd.errors.error(loc, "right hand side of unpack declaration must resolve to a tuple or expression sequence, not `%s`",

--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1159,8 +1159,8 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
     }
     do
     {
-        nextToken();
         const unpackLoc = token.loc;
+        nextToken();
         bool hasComma = false;
         auto vars = new AST.Dsymbols();
         while (token.value != TOK.rightParenthesis)


### PR DESCRIPTION
(A tuple pattern component having a UDA was already detected).

Also: Use the opening `(` position rather than the first component's to show the error applies to the whole unpack declaration (ideally it would have an earlier token when there's a storage class, but this is an improvement).