### PR TITLE
[tuple-syntax] Prevent assigning to tuple literal

### DIFF
--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5832,6 +5832,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             new TemplateInstance(e.loc, Id.__Tuple, args));
         result = new CallExp(e.loc, se, e.elements);
         result = result.expressionSemantic(sc);
+        result.isCallExp().loweredFrom = e;
     }
 
     override void visit(ArrayLiteralExp e)
@@ -12443,8 +12444,30 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else if (exp.op == EXP.assign)
             {
-                if (Expression e = exp.isAssignExp().opOverloadAssign(sc, aliasThisStop))
+                if (Expression e = exp.opOverloadAssign(sc, aliasThisStop))
                 {
+                    // check assignment to tuple rvalue
+                    // needed until https://github.com/dlang/dmd/issues/21507 is fixed
+                    bool checkCall(Expression e)
+                    {
+                        CallExp ce = e.isCallExp();
+                        if (ce && ce.loweredFrom && ce.loweredFrom.isTupleLiteralExp())
+                        {
+                            error(exp.loc, "cannot assign to tuple literal");
+                            setError();
+                            return false;
+                        }
+                        return true;
+                    }
+                    if (!checkCall(e1x))
+                        return;
+                    // CondExp with tuple can't be lowered into a tuple assignment like
+                    // comma/mixin is so we have to check for it
+                    if (auto ce = e1x.isCondExp())
+                    {
+                        if (!checkCall(ce.e1) || !checkCall(ce.e2))
+                            return;
+                    }
                     result = e;
                     return;
                 }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -15439,6 +15439,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
         r.expressionSemantic(sc);
+        if (auto ce = r.isCommaExp())
+            ce.originalExp = ue;
         r = resolveProperties(sc, r);
         result = r;
     }

--- a/compiler/src/dmd/expressionsem.d
+++ b/compiler/src/dmd/expressionsem.d
@@ -5832,7 +5832,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             new TemplateInstance(e.loc, Id.__Tuple, args));
         result = new CallExp(e.loc, se, e.elements);
         result = result.expressionSemantic(sc);
-        result.isCallExp().loweredFrom = e;
+        if (auto ce = result.isCallExp())
+            ce.loweredFrom = e;
     }
 
     override void visit(ArrayLiteralExp e)

--- a/compiler/test/fail_compilation/tuple_assign.d
+++ b/compiler/test/fail_compilation/tuple_assign.d
@@ -3,17 +3,17 @@ REQUIRED_ARGS: -preview=tuples
 TEST_OUTPUT:
 ---
 fail_compilation/tuple_assign.d(26): Error: cannot implicitly convert expression `t.__expand_field_0` of type `string` to `int`
-fail_compilation/tuple_assign.d(26): Error: cannot resolve type for b = t.__expand_field_0 , c = t.__expand_field_1
+fail_compilation/tuple_assign.d(26): Error: cannot resolve type for (b, c) = t
 fail_compilation/tuple_assign.d(28): Error: right hand side of unpack statement must resolve to a tuple or expression sequence, not `int`
 fail_compilation/tuple_assign.d(30): Error: cannot modify constant `2`
-fail_compilation/tuple_assign.d(30): Error: cannot resolve type for (Tuple!int __tup38 = __tup38 = 0 , (1,);) , 2 = __tup38._...
+fail_compilation/tuple_assign.d(30): Error: cannot resolve type for (2,) = (1,)
 fail_compilation/tuple_assign.d(31): Error: incompatible number of components for unpack statement (`1` vs. `2`)
 fail_compilation/tuple_assign.d(33): Error: cannot implicitly convert expression `0` of type `int` to `string`
-fail_compilation/tuple_assign.d(33): Error: cannot resolve type for b = 0 , a = 0
+fail_compilation/tuple_assign.d(33): Error: cannot resolve type for (b, a) = Seq!(0, 0)
 fail_compilation/tuple_assign.d(34): Error: incompatible number of components for unpack statement (`2` vs. `1`)
 fail_compilation/tuple_assign.d(36): Error: cannot specify `enum` for unpack statement components
 fail_compilation/tuple_assign.d(37): Error: right hand side of unpack statement must resolve to a tuple or expression sequence, not `string`
-fail_compilation/tuple_assign.d(37): Error: cannot resolve type for (int m = 12;) , (n,) = "val"
+fail_compilation/tuple_assign.d(37): Error: cannot resolve type for (((int m = 12;)), (n,) = "val") = Seq!(12, "val")
 ---
 */
 

--- a/compiler/test/fail_compilation/tuple_assign.d
+++ b/compiler/test/fail_compilation/tuple_assign.d
@@ -6,7 +6,7 @@ fail_compilation/tuple_assign.d(26): Error: cannot implicitly convert expression
 fail_compilation/tuple_assign.d(26): Error: cannot resolve type for b = t.__expand_field_0 , c = t.__expand_field_1
 fail_compilation/tuple_assign.d(28): Error: right hand side of unpack statement must resolve to a tuple or expression sequence, not `int`
 fail_compilation/tuple_assign.d(30): Error: cannot modify constant `2`
-fail_compilation/tuple_assign.d(30): Error: cannot resolve type for (Tuple!int __tup38 = __tup38 = 0 , __tup38.this(1);) , 2 ...
+fail_compilation/tuple_assign.d(30): Error: cannot resolve type for (Tuple!int __tup38 = __tup38 = 0 , (1,);) , 2 = __tup38._...
 fail_compilation/tuple_assign.d(31): Error: incompatible number of components for unpack statement (`1` vs. `2`)
 fail_compilation/tuple_assign.d(33): Error: cannot implicitly convert expression `0` of type `int` to `string`
 fail_compilation/tuple_assign.d(33): Error: cannot resolve type for b = 0 , a = 0

--- a/compiler/test/fail_compilation/tuples.d
+++ b/compiler/test/fail_compilation/tuples.d
@@ -1,0 +1,38 @@
+/*
+REQUIRED_ARGS: -preview=tuples -verrors=context
+TEST_OUTPUT:
+---
+fail_compilation/tuples.d(25): Error: cannot assign to tuple literal
+    a++, (a, b) = (3, 4);
+                ^
+fail_compilation/tuples.d(29): Error: cannot assign to tuple literal
+    mixin("(s, b)") = t2;
+                    ^
+fail_compilation/tuples.d(32): Error: cannot assign to tuple literal
+    (x ? (x, b) : (x, b)) = (true, 2);
+                          ^
+fail_compilation/tuples.d(34): Error: rvalue `("", 0)` cannot be assigned to `ref t`
+    ref t = ("", 0);
+        ^
+---
+*/
+
+// Reject assignment to tuple rvalue.
+// Note only a statement starting `TupleLiteralExp =` is an UnpackExp
+void main()
+{
+    int a, b;
+    a++, (a, b) = (3, 4);
+
+    auto t2 = ("six", 7);
+    string s;
+    mixin("(s, b)") = t2;
+
+    bool x;
+    (x ? (x, b) : (x, b)) = (true, 2);
+
+    ref t = ("", 0);
+
+    // a field of an rvalue struct is an lvalue
+    (5, 6)[0]++;
+}


### PR DESCRIPTION
Set `CallExp.loweredFrom` in `TupleLiteralExp` semantic. (This also helps in error messages).
Detect it in `AssignExp` semantic.