### PR TITLE
Fix ICE: Improve constructor logic for type preservation

### DIFF
--- a/compiler/src/dmd/glue/e2ir.d
+++ b/compiler/src/dmd/glue/e2ir.d
@@ -943,7 +943,10 @@ elem* toElem(Expression e, ref IRState irs)
     elem* visitDeclaration(DeclarationExp de)
     {
         //printf("DeclarationExp.toElem() %s\n", de.toChars());
-        return Dsymbol_toElem(de.declaration, irs);
+        elem* e = Dsymbol_toElem(de.declaration, irs);
+        if (e && de.type && de.type.toBasetype().ty == Tvoid)
+            e.Ety = TYvoid;
+        return e;
     }
 
     /***************************************


### PR DESCRIPTION
Refactor handling of 'e' in constructor logic to preserve type information for structs and arrays.

From [this post](https://forum.dlang.org/source/1084rb7$2km2$1@digitalmars.com), fixes an ICE in the following example code:

```d
import std.stdio;
import core.lifetime;

struct S{
    this(ref S){
        writeln("S copied");
    }
    this(S){
        writeln("S moved");
    }
    ~this(){
        writeln("S destroyed");
    }
}

struct Tuple(T...) {
    T expand;
    alias expand this;
    this(ref Tuple rhs){
        this.expand=rhs.expand;
        writeln("Tuple copied");
    }
    this(Tuple rhs){
        static foreach(i;0..expand.length)
            this.expand[i]=move(rhs.expand[i]);
        writeln("S moved");
    }
    ~this(){
        writeln("Tuple destroyed");
    }
}

void main(){
    Tuple!(S, S) t;
    auto (a, b) = move(t);
}
```