### PR TITLE
[unpacking] Disallow `(T x,) = tup, i = 1;`

### DIFF
--- a/compiler/src/dmd/parse.d
+++ b/compiler/src/dmd/parse.d
@@ -1305,6 +1305,11 @@ class Parser(AST, Lexer = dmd.lexer.Lexer) : Lexer
             {
                 assert(global.params.tuples);
                 s = parseUnpackDeclaration(storageClass, true);
+                if (!storageClass && token.value == TOK.comma)
+                {
+                    // prevent `(T x,) = tup, i = 1;`
+                    error("`;` expected after tuple pattern, not `,`");
+                }
             }
             else
             {

--- a/compiler/test/fail_compilation/unpacking.d
+++ b/compiler/test/fail_compilation/unpacking.d
@@ -2,18 +2,19 @@
 REQUIRED_ARGS: -preview=tuples -vcolumns
 TEST_OUTPUT:
 ---
-fail_compilation/unpacking.d(29,14): Error: unpacked variable `b` needs a type or at least one storage class, did you mean `auto b`?
-fail_compilation/unpacking.d(30,15): Error: unpacked variable `b` needs a type or at least one storage class, did you mean `auto b`?
-fail_compilation/unpacking.d(30,18): Error: unpacked variable `c` needs a type or at least one storage class, did you mean `auto c`?
-fail_compilation/unpacking.d(31,23): Error: unpacked variable `c` needs a type or at least one storage class, did you mean `auto c`?
-fail_compilation/unpacking.d(33,16): Error: found `,` when expecting `=` following unpack declaration
-fail_compilation/unpacking.d(34,10): Error: unexpected identifier `a` in declarator
-fail_compilation/unpacking.d(34,17): Error: unexpected identifier `b` in declarator
-fail_compilation/unpacking.d(36,17): Error: expected identifier after type `int` in unpack declaration
-fail_compilation/unpacking.d(38,16): Error: `auto ref` unpacked variables are not supported
-fail_compilation/unpacking.d(39,25): Error: unpacking `auto ref` parameters is not supported
-fail_compilation/unpacking.d(40,21): Error: unpacking `lazy` parameters is not supported
-fail_compilation/unpacking.d(40,34): Error: unpacking `out` parameters is not supported
+fail_compilation/unpacking.d(30,14): Error: unpacked variable `b` needs a type or at least one storage class, did you mean `auto b`?
+fail_compilation/unpacking.d(31,15): Error: unpacked variable `b` needs a type or at least one storage class, did you mean `auto b`?
+fail_compilation/unpacking.d(31,18): Error: unpacked variable `c` needs a type or at least one storage class, did you mean `auto c`?
+fail_compilation/unpacking.d(32,23): Error: unpacked variable `c` needs a type or at least one storage class, did you mean `auto c`?
+fail_compilation/unpacking.d(34,16): Error: found `,` when expecting `=` following unpack declaration
+fail_compilation/unpacking.d(35,10): Error: unexpected identifier `a` in declarator
+fail_compilation/unpacking.d(35,17): Error: unexpected identifier `b` in declarator
+fail_compilation/unpacking.d(37,17): Error: expected identifier after type `int` in unpack declaration
+fail_compilation/unpacking.d(39,16): Error: `auto ref` unpacked variables are not supported
+fail_compilation/unpacking.d(40,25): Error: unpacking `auto ref` parameters is not supported
+fail_compilation/unpacking.d(41,21): Error: unpacking `lazy` parameters is not supported
+fail_compilation/unpacking.d(41,34): Error: unpacking `out` parameters is not supported
+fail_compilation/unpacking.d(43,23): Error: `;` expected after tuple pattern, not `,`
 ---
 */
 
@@ -26,16 +27,18 @@ auto tuple(T...)(T args) => Tuple!T(args);
 
 void main() // check parse errors
 {
-    (int a, b) = tuple(1, "2"); // error
+    (int a, b) = tuple(1, "2"); // error, lone b
     (int a, (b, c)) = tuple(1, tuple("2", 3.0)); // error
     (int a, (auto b, c)) = tuple(1, tuple("2", 3.0)); // error
 
-    auto (a, b), c = t; // error
+    auto (a, b), c = t; // error, pattern missing init
     (int a, int b), c = t; // error
 
-    (char a, int) = t; // error
+    (char a, int) = t; // error, missing ident
 
-    (auto ref a,) = t; // error
+    (auto ref a,) = t; // error, illegal storage
     alias a = (auto ref (x,)) {}; // error
     alias a = (lazy (x,), y, out (z,)) {}; // error
+
+    (int a, int b) = t, c = 1; // error, comma requires storage class
 }


### PR DESCRIPTION
cc @metalang.

BTW I've been working on the spec grammar. The approved DIP grammar is [here](https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1053.md#unpacking-declarations-1). However, I need to change the grammar to support mixing tuple patterns and normal declarators in a declaration, like the unpacking branch currently does. E.g. `auto (x, y) = seq, z = 3;`. That should work fine for AutoDeclaration, with an addition to [AutoAssignment](https:///dlang.org/spec/declaration.html#AutoAssignment). AutoDeclaration requires a storage class though, so I plan to add a rule to `VarDeclarations`. I've done this locally, I'll submit it in a separate PR later.

---
`(T x,) = tup, i = 1;` needs to error, as there is no type or storage class given for `i`. Solution: Require semi-colon after TuplePattern = Initializer. Although we could allow a list of multiple tuple pattern/init pairs, this doesn't buy any brevity over just using `;` instead of `,`. Only supporting one pair lets us simplify the grammar to:

```
VarDeclarations:
    ...
    TuplePattern = Initializer;

TuplePattern:
    `(` TuplePatternComponents `)`
```
Note AutoDeclaration will still support commas, e.g. `auto (x,) = tup, i = 1;`.

Also, the simpler VarDeclarations syntax is essentially a special case of `UnpackExp` (which was merged to the tuple-syntax branch - see #16). Whereas supporting multiple pattern/init pairs would probably conflict with that in a function.