### PR TITLE
[spec/declaration] Unpacking declarations

### DIFF
--- a/changelog/dmd.tuple-unpacking.dd
+++ b/changelog/dmd.tuple-unpacking.dd
@@ -1,6 +1,7 @@
 Tuple unpacking is now supported!
 
-D now supports tuple unpacking for variable declarations and `foreach` loops.
+D now supports tuple unpacking for variable declarations, `foreach` loops, and function literal
+template parameters.
 This feature is available as a preview and can be enabled with the `-preview=tuples` compiler switch.
 It allows extracting multiple values from a tuple or compile-time sequence directly into distinct variables.
 

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -43,6 +43,7 @@ $(GRAMMAR
 $(GNAME VarDeclarations):
     $(GLINK StorageClasses)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 type, TypeSuffixes)$(OPT) $(GLINK IdentifierInitializers) $(D ;)
     $(GLINK AutoDeclaration)
+    $(GLINK TuplePattern) `=` $(GLINK AssignExpression)
 
 $(GNAME IdentifierInitializers): $(LEGACY_LNAME2 Declarators, DeclaratorIdentifierList)
     $(GLINK IdentifierInitializer)
@@ -69,6 +70,8 @@ $(GNAME Declarator): $(LEGACY_LNAME2 VarDeclarator)
       $(DDSUBLINK spec/struct, bitfields, bit field).
     * When the *Identifier* has *TemplateParameters*, it is a
       $(DDSUBLINK spec/template, variable-template, variable template).
+    * When there's a *TuplePattern*, the *AssignExpression*
+      $(RELATIVE_LINK2 unpacking-declarations, is unpacked) into component declarations.
 
     $(P See also: $(RELATIVE_LINK2 declaration_syntax, Declaration Syntax).)
 
@@ -293,6 +296,7 @@ $(GNAME AutoAssignments):
 
 $(GNAME AutoAssignment):
     $(GLINK_LEX Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK Initializer)
+    $(GLINK TuplePattern) `=` $(GLINK AssignExpression)
 )
 
         $(P If a declaration starts with a $(I StorageClass) and has
@@ -324,6 +328,83 @@ auto c = new C();  // c is a handle to an instance of class C
         ---
         auto v = ["resistance", "is", "useless"]; // type is string[], not string[3]
         ---
+
+$(H3 $(LNAME2 unpacking-declarations, Unpacking Declarations))
+
+        $(P $(GLINK VarDeclarations) and $(GLINK AutoDeclaration) support initializing
+        one or more variables in a *tuple pattern* from an $(GLINK AssignExpression).
+        The *AssignExpression* must implicitly convert to a
+        $(DDSUBLINK spec/template, homogeneous_sequences, value sequence).)
+
+$(GRAMMAR
+$(GNAME TuplePattern):
+    `(` $(GLINK TuplePatternComponents) `)`
+
+$(GNAME TuplePatternComponents):
+    $(GLINK TuplePatternComponent) `,`
+    $(GLINK TuplePatternComponent) `,` $(GLINK TuplePatternComponent)
+    $(GLINK TuplePatternComponent) `,` $(GLINK TuplePatternComponents)
+
+$(GNAME TuplePatternComponent):
+    $(GLINK StorageClasses)$(OPT) $(GLINK Identifier)
+    $(GLINK StorageClasses)$(OPT) $(GLINK BasicType) $(GLINK TypeSuffixes)$(OPT) $(GLINK Identifier)
+    $(GLINK StorageClasses)$(OPT) $(GLINK TuplePattern)
+)
+
+        - Each component of the tuple pattern corresponds to an element of the value sequence.
+        - Components are separated by commas.
+        - For a pattern with a single component, a comma must precede the closing parenthesis.
+
+```d
+import std.typecons : tuple;
+
+(int a, auto b) = tuple(1, "2"); // unpacking declaration
+assert(a == 1);
+assert(b == "2");
+```
+        $(P The unpacking declaration above is lowered to e.g.:)
+```d
+auto temp = tuple(1, "2");
+int a = temp[0];
+auto b = temp[1];
+```
+        $(P **See also:** $(REF Tuple, std,typecons).)
+
+        $(P When the tuple pattern has no storage class, each identifier
+        must have a type or a component storage class:)
+```d
+(int a, b) = tuple(1, "2"); // Error: `b` has no type or storage class
+```
+        $(P When there is a storage class for a pattern, each component of the pattern can
+        be just an identifier. Each variable's type will be inferred from the corresponding
+        sequence element:)
+
+```d
+import std.typecons : tuple;
+
+auto (a, b) = tuple(1, "2");
+static assert(is(typeof(a) == int));
+static assert(is(typeof(b) == string));
+
+auto (a, immutable b, c) = tuple(1, "2", 3.0);
+static assert(is(typeof(a) == int));
+static assert(is(typeof(b) == immutable string));
+static assert(is(typeof(c) == double));
+```
+
+        $(P Patterns can be nested:)
+
+```d
+auto t = tuple(1, tuple("2", 3.0));
+// the following are equivalent:
+auto (a, (b, c)) = t;
+(int a, (string b, double c)) = t;
+(int a, auto (b, c)) = t;
+(int a, (auto b, auto c)) = t;
+```
+
+        $(P `static` or `enum` can be applied to the whole declaration, but not to individual components.)
+
 
 $(H3 $(LNAME2 global_static_init, Global and Static Initializers))
 

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -355,31 +355,31 @@ $(GNAME TuplePatternComponent):
         - Components are separated by commas.
         - For a pattern with a single component, a comma must precede the closing parenthesis.
 
-```d
+---
 import std.typecons : tuple;
 
 (int a, auto b) = tuple(1, "2"); // unpacking declaration
 assert(a == 1);
 assert(b == "2");
-```
+---
         $(P The unpacking declaration above is lowered to e.g.:)
-```d
+---
 auto temp = tuple(1, "2");
 int a = temp[0];
 auto b = temp[1];
-```
+---
         $(P **See also:** $(REF Tuple, std,typecons).)
 
         $(P When the tuple pattern has no storage class, each identifier
-        must have a type or a component storage class:)
-```d
+        must either have a type or a storage class applying to it:)
+---
 (int a, b) = tuple(1, "2"); // Error: `b` has no type or storage class
-```
+---
         $(P When there is a storage class for a pattern, each component of the pattern can
         be just an identifier. Each variable's type will be inferred from the corresponding
         sequence element:)
 
-```d
+---
 import std.typecons : tuple;
 
 auto (a, b) = tuple(1, "2");
@@ -390,18 +390,18 @@ auto (a, immutable b, c) = tuple(1, "2", 3.0);
 static assert(is(typeof(a) == int));
 static assert(is(typeof(b) == immutable string));
 static assert(is(typeof(c) == double));
-```
+---
 
         $(P Patterns can be nested:)
 
-```d
+---
 auto t = tuple(1, tuple("2", 3.0));
 // the following are equivalent:
 auto (a, (b, c)) = t;
 (int a, (string b, double c)) = t;
 (int a, auto (b, c)) = t;
 (int a, (auto b, auto c)) = t;
-```
+---
 
         $(P `static` or `enum` can be applied to the whole declaration, but not to individual components.)
 

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -370,7 +370,7 @@ auto b = temp[1];
 ---
         $(P **See also:** $(REF Tuple, std,typecons).)
 
-        $(P When the tuple pattern has no storage class, each identifier
+        $(P When the tuple pattern has no storage class, each component that declares a variable
         must either have a type or a storage class applying to it:)
 ---
 (int a, b) = tuple(1, "2"); // Error: `b` has no type or storage class

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -43,7 +43,7 @@ $(GRAMMAR
 $(GNAME VarDeclarations):
     $(GLINK StorageClasses)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 type, TypeSuffixes)$(OPT) $(GLINK IdentifierInitializers) $(D ;)
     $(GLINK AutoDeclaration)
-    $(GLINK TuplePattern) `=` $(GLINK AssignExpression)
+    $(GLINK TuplePattern) `=` $(GLINK2 expression, AssignExpression)
 
 $(GNAME IdentifierInitializers): $(LEGACY_LNAME2 Declarators, DeclaratorIdentifierList)
     $(GLINK IdentifierInitializer)
@@ -296,7 +296,7 @@ $(GNAME AutoAssignments):
 
 $(GNAME AutoAssignment):
     $(GLINK_LEX Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK Initializer)
-    $(GLINK TuplePattern) `=` $(GLINK AssignExpression)
+    $(GLINK TuplePattern) `=` $(GLINK2 expression, AssignExpression)
 )
 
         $(P If a declaration starts with a $(I StorageClass) and has
@@ -332,7 +332,7 @@ auto c = new C();  // c is a handle to an instance of class C
 $(H3 $(LNAME2 unpacking-declarations, Unpacking Declarations))
 
         $(P $(GLINK VarDeclarations) and $(GLINK AutoDeclaration) support initializing
-        one or more variables in a *tuple pattern* from an $(GLINK AssignExpression).
+        one or more variables in a *tuple pattern* from an $(GLINK2 expression, AssignExpression).
         The *AssignExpression* must implicitly convert to a
         $(DDSUBLINK spec/template, homogeneous_sequences, value sequence).)
 

--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -346,8 +346,8 @@ $(GNAME TuplePatternComponents):
     $(GLINK TuplePatternComponent) `,` $(GLINK TuplePatternComponents)
 
 $(GNAME TuplePatternComponent):
-    $(GLINK StorageClasses)$(OPT) $(GLINK Identifier)
-    $(GLINK StorageClasses)$(OPT) $(GLINK BasicType) $(GLINK TypeSuffixes)$(OPT) $(GLINK Identifier)
+    $(GLINK StorageClasses)$(OPT) $(GLINK_LEX Identifier)
+    $(GLINK StorageClasses)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 type, TypeSuffixes)$(OPT) $(GLINK_LEX Identifier)
     $(GLINK StorageClasses)$(OPT) $(GLINK TuplePattern)
 )
 

--- a/spec/expression.dd
+++ b/spec/expression.dd
@@ -2702,6 +2702,9 @@ $(H4 $(LNAME2 function-literal-alias, Function Literal Templates))
         ---
         )
 
+    $(P A function literal template parameter $(DDSUBLINK spec/function, unpacking-parameters,
+    can use unpacking).)
+
 $(H4 $(LNAME2 lambda-return-type, Return Type Inference))
 
     $(P The return type of the $(GLINK FunctionLiteral) can be

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -47,6 +47,8 @@ $(GNAME Parameter):
     $(GLINK ParameterDeclaration) $(D ...)
     $(GLINK ParameterDeclaration) $(D =) $(ASSIGNEXPRESSION)
     $(GLINK ParameterDeclaration) $(D =) $(ASSIGNEXPRESSION) $(D ...)
+    $(GLINK ParameterAttributes)$(OPT) $(GLINK ParameterTuplePattern)
+    $(GLINK ParameterAttributes)$(OPT) $(GLINK ParameterTuplePattern) = $(GLINK2 expression, AssignExpression)
 
 $(GNAME ParameterDeclaration):
     $(GLINK ParameterAttributes)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 declaration, Declarator)
@@ -2281,6 +2283,48 @@ int* test(scope int* ptr)
 $(H3 $(LNAME2 udas-parameters, User-Defined Attributes for Parameters))
 
 See also: $(GLINK2_ALTTEXT attribute, UserDefinedAttribute, User-Defined Attributes)
+
+$(H3 $(LNAME2 unpacking-parameters, Unpacking Parameters))
+
+$(GRAMMAR
+$(GNAME ParameterTuplePattern):
+    `(` $(GLINK ParameterTupleComponents) `)`
+
+$(GNAME ParameterTupleComponents):
+    $(GLINK ParameterTupleComponent) `,`
+    $(GLINK ParameterTupleComponent) `,` $(GLINK ParameterTupleComponent)
+    $(GLINK ParameterTupleComponent) `,` $(GLINK ParameterTupleComponents)
+
+$(GNAME ParameterTupleComponent):
+    $(GLINK ParameterAttributes)$(OPT) $(GLINK_LEX Identifier)
+    $(GLINK ParameterAttributes)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 type, TypeSuffixes)$(OPT) $(GLINK_LEX Identifier)
+    $(GLINK ParameterAttributes)$(OPT) $(GLINK ParameterTuplePattern)
+)
+
+        $(P A $(DDSUBLINK spec/expression, function-literal-alias, function literal template)
+        with untyped *ParameterTupleComponents* is supported. The corresponding function
+        argument will be unpacked into component variables:)
+
+---
+import std.typecons : tuple;
+
+alias dg = ((x, y), z) => writeln(x, " ", y, " ", z);
+dg(tuple(1, 2), 3); // "1 2 3\n"
+---
+        $(NOTE A typed *ParameterTupleComponent* is parsed, but cannot be supported without
+        compiler-recognised tuple types.)
+
+        $(P `((x, y), z) { ... }` is lowered to `(__arg0, z) { auto (x, y) = __arg0; ... }`.
+        In general, lowering preserves and copies storage classes from
+        the parameter to an $(DDSUBLINK spec/declaration, unpacking-declarations,
+        unpacking declaration) in the function body.)
+
+        - The `ref` storage class is copied outwards, e.g., `((ref a, b), c) { ... }` gets lowered to
+          `(ref __arg0, c) { (ref a, auto b) = __arg0; ... }`.
+        - `out` can be applied to the whole parameter, but not to individual components.
+        - `auto ref` and `lazy` cannot be applied to an unpacking parameter.
+
+        $(NOTE `out` unpacking parameters are not supported by the current implementation, but may be added at a future date.)
 
 $(H3 $(LNAME2 variadic, Variadic Functions))
 

--- a/spec/statement.dd
+++ b/spec/statement.dd
@@ -519,6 +519,7 @@ $(GNAME ForeachType):
     $(GLINK ForeachTypeAttributes)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 declaration, Declarator)
     $(GLINK ForeachTypeAttributes)$(OPT) $(GLINK_LEX Identifier)
     $(GLINK ForeachTypeAttributes)$(OPT) $(D alias) $(GLINK_LEX Identifier)
+    $(GLINK ForeachTypeAttributes)$(OPT) $(GLINK ForeachTuplePattern)
 
 $(GNAME ForeachTypeAttributes):
     $(GLINK ForeachTypeAttribute)
@@ -1311,6 +1312,117 @@ aa = null; // OK
         $(NOTE Resizing or reassigning a dynamic or associative array during
         `foreach` is still `@safe`.
         )
+
+$(H3 $(LNAME2 foreach-unpacking, Unpacking Foreach Variables))
+
+        $(P Similarly to $(DDSUBLINK spec/declaration, unpacking-declarations,
+        unpacking variable declarations), $(GLINK AggregateForeach) supports unpacking
+        *ForeachType* declarations. The `auto` storage class is implied for a tuple pattern unless overridden.)
+
+$(GRAMMAR
+$(GNAME ForeachTuplePattern):
+    `(` $(GLINK ForeachTupleComponents) `)`
+
+$(GNAME ForeachTupleComponents):
+    $(GLINK ForeachTupleComponent) `,`
+    $(GLINK ForeachTupleComponent) `,` $(GLINK ForeachTupleComponent)
+    $(GLINK ForeachTupleComponent) `,` $(GLINK ForeachTupleComponents)
+
+$(GNAME ForeachTupleComponent):
+    $(GLINK ForeachTypeAttributes)$(OPT) $(GLINK_LEX Identifier)
+    $(GLINK ForeachTypeAttributes)$(OPT) $(GLINK2 type, BasicType) $(GLINK2 type, TypeSuffixes)$(OPT) $(GLINK_LEX Identifier)
+    $(GLINK ForeachTypeAttributes)$(OPT) $(GLINK ForeachTuplePattern)
+)
+        $(P The following `foreach` statements are equivalent:)
+
+---
+import std.typecons : tuple;
+
+auto arr = [tuple(1, "2"), tuple(3, "4"), tuple(5, "6")];
+
+foreach ((x, y); arr)
+{
+    writeln(x, " ", y); // "1 2\n3 4\n5 6\n"
+}
+
+foreach ((int x, string y); arr)
+{
+    writeln(x, " ", y);// "1 2\n3 4\n5 6\n"
+}
+---
+        $(P An index variable can be declared alongside
+        an unpacked element variable (when the $(GLINK ForeachAggregate) supports it):)
+
+---
+import std.typecons : tuple;
+
+auto arr = [tuple(1, 2), tuple(3, 4)];
+// declare index for array & unpack tuple elements
+foreach (i, (x, y); arr)
+{
+    assert(x == 2 * i + 1);
+    assert(y == 2 * i + 2);
+}
+---
+        $(P Nested tuples can be unpacked. Below, $(REF_SHORT enumerate, std,range) returns a
+        range of element type `Tuple!(size_t, Tuple!(int, int))`. The outer
+        tuple is $(RELATIVE_LINK2 front-seq, implicitly unwrapped):)
+---
+import std.range : enumerate;
+import std.typecons : tuple;
+
+auto arr = [tuple(1, 2), tuple(3, 4)];
+// unpack a range of nested tuples
+foreach (i, (j, k); enumerate(arr))
+{
+    writeln(i," ",j," ",k); // "0 1 2\n1 3 4\n"
+}
+---
+        $(P The index variable can also be unpacked:)
+
+---
+import std.typecons : tuple;
+
+auto aa = [tuple(1, 2): "hi", tuple(3, 4): "bye"];
+// unpack AA tuple keys
+foreach ((a, b), s; aa)
+{
+    writeln(a, b, s); // "12hi\n34bye\n"
+}
+---
+        $(P Normal $(GLINK ForeachTypeAttribute) storage classes are supported,
+        and they can apply to tuple component variables:)
+
+---
+import std.typecons : tuple;
+
+auto arr = [tuple(1, 2), tuple(3, 4)];
+foreach ((ref x, y); arr)
+{
+    x = 2 * y;
+}
+assert(arr == [tuple(4, 2), tuple(8, 4)]);
+
+foreach (const (x, y); arr)
+{
+    static assert(is(typeof(x) == const(int)));
+    static assert(is(typeof(y) == const(int)));
+    assert(x == 2 * y);
+}
+---
+        $(P Unpacking can be used with $(GLINK2 version, StaticForeach):)
+
+---
+import std.typecons : tuple;
+
+static foreach ((a, b); [tuple(1, 2), tuple(3, 4)])
+{
+    pragma(msg, a, b); // "12\n34\n"
+}
+---
+
+        $(P Unpacking can also be used with $(RELATIVE_LINK2 op-apply, `opApply`).)
+
 
 $(H3 $(LEGACY_LNAME2 ForeachRangeStatement, foreach-range-statement, Foreach Range Statement))
 

--- a/spec/version.dd
+++ b/spec/version.dd
@@ -701,8 +701,9 @@ void fun()
 ---
 )
 
-        $(P `static foreach` supports sequence expansion
-        $(DDSUBLINK spec/statement, foreach_over_tuples, like `foreach`).)
+        $(P `static` *AggregateForeach* supports sequence expansion
+        $(DDSUBLINK spec/statement, foreach_over_tuples, like `foreach`),
+        as well as unpacking $(GLINK2 statement, ForeachTuplePattern)s.)
 
 $(H3 $(LNAME2 break-continue, `break` and `continue`))
 


### PR DESCRIPTION
Grammar changes (see #20 for details) since approved DIP:
AutoDeclaration allows interleaved tuple and non-tuple declarators. 
VarDeclarations now only takes one TuplePattern.
Also change Initializer to AssignExpression (`= void` is not allowed).

Wording is a bit tweaked but [based on DIP](https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1053.md#unpacking-declarations), as are examples.

~~Parameter and `foreach` unpacking still to do, but this is the main part.~~ Now done!